### PR TITLE
Write result duration into local database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Project-specific files
+benchmark.db
+tests/temp/*

--- a/README.md
+++ b/README.md
@@ -9,9 +9,37 @@ The `cubed benchmarks` test suite can be run locally with the following steps:
 1. Create a conda environment using `ci/environment.yml`
 2. Run tests with `python -m pytest tests`.
 
+## Benchmarking
+
+The `cubed-benchmarks` test suite contains a series of pytest fixtures which enable
+benchmarking metrics to be collected and stored for historical and regression analysis.
+By default, these metrics are not collected and stored, but they can be enabled
+by including the `--benchmark` flag in your pytest invocation.
+
+From a high level, here is how the benchmarking works:
+
+* Data from individual test runs are collected and stored in a local sqlite database.
+  The schema for this database is stored in `benchmark_schema.py`
+* The local sqlite databases are appended to a global historical record, stored in S3.
+* The historical data can be analyzed using any of a number of tools.
+
+### Running the benchmarks locally
+
+You can collect benchmarking data by running pytest with the `--benchmark` flag.
+This will create a local `benchmark.db` sqlite file in the root of the repository.
+If you run a test suite multiple times with benchmarking,
+the data will be appended to the database.
+
+You can compare with historical data by downloading the global database from S3 first:
+
+```bash
+aws s3 cp s3://cubed-runtime-ci/benchmarks/benchmark.db ./benchmark.db
+pytest --benchmark
+```
+
 ## Acknowledgements
 
-This repository is heavily inspired by [`Coiled Benchmarks`](https://github.com/coiled/benchmarks/).
+This repository is heavily inspired by [`Coiled Benchmarks`](https://github.com/coiled/benchmarks/), with many sections of code being lifted directly.
 
 ## License
 

--- a/benchmark_schema.py
+++ b/benchmark_schema.py
@@ -37,3 +37,9 @@ class TestRun(Base):
     # Memory data
     average_memory = Column(Float, nullable=True)
     peak_memory = Column(Float, nullable=True)
+    projected_memory = Column(Float, nullable=True)
+
+    # Other diagnostics data
+    number_of_tasks_run = Column(Integer, nullable=True)
+    intermediate_data_stored = Column(Float, nullable=True)
+    container_seconds = Column(Float, nullable=True)

--- a/benchmark_schema.py
+++ b/benchmark_schema.py
@@ -1,0 +1,39 @@
+from sqlalchemy import Column, DateTime, Float, Integer, String
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+
+class TestRun(Base):
+    __tablename__ = "test_run"
+
+    # unique run ID
+    id = Column(Integer, primary_key=True)
+
+    # pytest data
+    session_id = Column(String, nullable=False)
+    name = Column(String, nullable=False)
+    originalname = Column(String, nullable=False)
+    path = Column(String, nullable=True)
+    setup_outcome = Column(String, nullable=True)
+    call_outcome = Column(String, nullable=True)
+    teardown_outcome = Column(String, nullable=True)
+
+    # Runtime data
+    cubed_version = Column(String, nullable=True)
+    cubed_xarray_version = Column(String, nullable=True)
+    lithops_version = Column(String, nullable=True)
+    python_version = Column(String, nullable=True)
+    platform = Column(String, nullable=True)
+
+    # CI runner data
+    ci_run_url = Column(String, nullable=True)
+
+    # Wall clock data
+    start = Column(DateTime, nullable=True)
+    end = Column(DateTime, nullable=True)
+    duration = Column(Float, nullable=True)
+
+    # Memory data
+    average_memory = Column(Float, nullable=True)
+    peak_memory = Column(Float, nullable=True)

--- a/benchmark_schema.py
+++ b/benchmark_schema.py
@@ -21,6 +21,7 @@ class TestRun(Base):
 
     # Runtime data
     cubed_version = Column(String, nullable=True)
+    xarray_version = Column(String, nullable=True)
     cubed_xarray_version = Column(String, nullable=True)
     lithops_version = Column(String, nullable=True)
     python_version = Column(String, nullable=True)

--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -6,7 +6,7 @@ import cubed.array_api as xp
 from ..utils import run_benchmark
 
 
-def test_quad_means(runtime):
+def test_quad_means(runtime, benchmark_time):
     # from cubed.tests.test_core.test_plan_quad_means
 
     spec = runtime

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,23 @@
+import contextlib
+import time
+import datetime
 import os
-import yaml
+import pathlib
+import sys
+
+from typing import Iterator
 
 import pytest
+import sqlalchemy
+from sqlalchemy.orm import Session
+import filelock
+import subprocess
 
 import cubed
 
 from .utils import spec_from_config_file
 
-from typing import Iterator
+from benchmark_schema import TestRun
 
 
 RUNTIME_CONFIGS = [
@@ -17,6 +27,167 @@ RUNTIME_CONFIGS = [
     #'configs/lithops_aws_1Z.yaml'
     #'configs/coiled_aws.yaml'
 ]
+
+
+TEST_DIR = pathlib.Path("./tests").absolute()
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--benchmark", action="store_true", help="Collect benchmarking data for tests"
+    )
+
+
+# ############################################### #
+#            BENCHMARKING RELATED                 #
+# ############################################### #
+
+DB_NAME = os.environ.get("DB_NAME", "benchmark.db")
+
+
+if os.environ.get("GITHUB_SERVER_URL"):
+    WORKFLOW_URL = "/".join(
+        [
+            os.environ.get("GITHUB_SERVER_URL", ""),
+            os.environ.get("GITHUB_REPOSITORY", ""),
+            "actions",
+            "runs",
+            os.environ.get("GITHUB_RUN_ID", ""),
+        ]
+    )
+else:
+    WORKFLOW_URL = None
+
+
+@pytest.fixture(scope="session")
+def benchmark_db_engine(pytestconfig, tmp_path_factory):
+    """Session-scoped fixture for the SQLAlchemy engine for the benchmark sqlite database.
+
+    You can control the database name with the environment variable ``DB_NAME``,
+    which defaults to ``benchmark.db``. Most tests shouldn't need to include this
+    fixture directly.
+
+    Yields
+    ------
+    The SQLAlchemy engine if the ``--benchmark`` option is set, None otherwise.
+    """
+
+    if not pytestconfig.getoption("--benchmark"):
+        yield
+    else:
+        engine = sqlalchemy.create_engine(f"sqlite:///{DB_NAME}", future=True)
+
+        # get the temp directory shared by all workers
+        root_tmp_dir = tmp_path_factory.getbasetemp().parent
+        lock = root_tmp_dir / (DB_NAME + ".lock")
+
+        # Create the db if it does not exist already.
+        with filelock.FileLock(lock):
+            if not os.path.exists(DB_NAME):
+                with engine.connect() as conn:
+                    conn.execute(sqlalchemy.text("VACUUM"))
+
+        # TODO use alembic for database migration like Coiled Benchmarks does
+
+        yield engine
+
+
+@pytest.fixture(scope="function")
+def benchmark_db_session(benchmark_db_engine):
+    """SQLAlchemy session for a given test.
+
+    Most tests shouldn't need to include this fixture directly.
+
+    Yields
+    ------
+    SQLAlchemy session for the benchmark database engine if run as part of a benchmark,
+    None otherwise.
+    """
+    if not benchmark_db_engine:
+        yield
+    else:
+        with Session(benchmark_db_engine, future=True) as session, session.begin():
+            yield session
+
+
+@pytest.fixture(scope="function")
+def test_run_benchmark(benchmark_db_session, request, testrun_uid):
+    """SQLAlchemy ORM object representing a given test run.
+
+    By including this fixture in a test (or another fixture that includes it)
+    you trigger the test being written to the benchmark database. This fixture
+    includes data common to all tests, including python version, test name,
+    and the test outcome.
+
+    Yields
+    ------
+    SQLAlchemy ORM object representing a given test run if run as part of a benchmark,
+    None otherwise.
+    """
+    if not benchmark_db_session:
+        yield
+    else:
+        run = TestRun(
+            session_id=testrun_uid,
+            name=request.node.name,
+            originalname=request.node.originalname,
+            path=str(request.node.path.relative_to(TEST_DIR)),
+            cubed_version=cubed.__version__,
+            #cubed_xarray_version=cubed_xarray.__version__,
+            #xarray_version=xarray.__version__,
+            #lithops_version=lithops.__version__, 
+            python_version=".".join(map(str, sys.version_info)),
+            platform=sys.platform,
+            ci_run_url=WORKFLOW_URL,
+        )
+        yield run
+
+        rep = getattr(request.node, "rep_setup", None)
+        if rep:
+            run.setup_outcome = rep.outcome
+        rep = getattr(request.node, "rep_call", None)
+        if rep:
+            run.call_outcome = rep.outcome
+        rep = getattr(request.node, "rep_teardown", None)
+        if rep:
+            run.teardown_outcome = rep.outcome
+
+        benchmark_db_session.add(run)
+        benchmark_db_session.commit()
+
+
+@pytest.fixture(scope="function")
+def benchmark_time(test_run_benchmark):
+    """
+    Benchmark the wall clock time of executing some code.
+
+    Yields
+    ------
+    Context manager that records the wall clock time duration of executing
+    the ``with`` statement if run as part of a benchmark, or does nothing otherwise.
+
+    Example
+    -------
+    .. code-block:: python
+
+        def test_something(benchmark_time):
+            with benchmark_time:
+                do_something()
+    """
+
+    @contextlib.contextmanager
+    def _benchmark_time():
+        if not test_run_benchmark:
+            yield
+        else:
+            start = time.time()
+            yield
+            end = time.time()
+            test_run_benchmark.duration = end - start
+            test_run_benchmark.start = datetime.datetime.utcfromtimestamp(start)
+            test_run_benchmark.end = datetime.datetime.utcfromtimestamp(end)
+
+    return _benchmark_time()
 
 
 @pytest.fixture(params=RUNTIME_CONFIGS)


### PR DESCRIPTION
Records the duration time of the one test to a local database.

Doesn't actually work yet - if you run `pytest --benchmark` it gets as far as creating a `benchmark.db` file locally before erroring with

```
E       sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: test_run
```