### PR TITLE
Run on Lithops AWS

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
 dependencies:
 
-  - python >=3.9
+  - python >=3.9,<=3.11
   - pip
   - pytest
   - cubed >=0.13.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+addopts = -v -rsxfE --durations=0 --color=yes --strict-markers --strict-config

--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -1,28 +1,86 @@
+from functools import partial
+import random
+
+import fsspec
+import pytest
+import xarray as xr
+
 import cubed
 import cubed.random
-import cubed.array_api as xp
-
+from cubed.core.optimization import multiple_inputs_optimize_dag
+from cubed.extensions.rich import RichProgressBar
+from cubed.runtime.executors.python import PythonDagExecutor
 
 from ..utils import run
 
-
-def test_quad_means(runtime, benchmark_time):
-    # from cubed.tests.test_core.test_plan_quad_means
-
+@pytest.mark.parametrize("t_length", [50, 500, 5000])
+def test_quadratic_means_xarray(tmp_path, runtime, benchmark_time, t_length):
     spec = runtime
 
-    # TODO parametrize the scale through this parameter?
-    t_length = 50
+    if isinstance(spec.executor, PythonDagExecutor) and t_length > 50:
+        pytest.skip(f"Don't run large computation on {type(spec.executor)}")
 
-    # TODO write initial data out to bucket first to read from later
+    # set the random seed to ensure deterministic results
+    random.seed(42)
+
+    # create zarr test data (not timed)
     u = cubed.random.random((t_length, 1, 987, 1920), chunks=(10, 1, -1, -1), spec=spec)
     v = cubed.random.random((t_length, 1, 987, 1920), chunks=(10, 1, -1, -1), spec=spec)
-    
+    arrays = [u, v]
+    paths = [f"{spec.work_dir}/u_{t_length}.zarr", f"{spec.work_dir}/v_{t_length}.zarr"]
+    cubed.store(arrays, paths, compute_arrays_in_parallel=True, callbacks=[RichProgressBar()])
+
     # lazily define computation
-    uv = u * v
-    result = xp.mean(uv, axis=0, split_every=10, use_new_impl=True)
+    ds = xr.Dataset(
+        dict(
+            anom_u=(
+                ["time", "face", "j", "i"],
+                cubed.from_zarr(paths[0], spec=spec),
+            ),
+            anom_v=(
+                ["time", "face", "j", "i"],
+                cubed.from_zarr(paths[1], spec=spec),
+            ),
+        )
+    )
+    quad = ds**2
+    quad["uv"] = ds.anom_u * ds.anom_v
+    result = quad.mean(
+        "time", skipna=False, use_new_impl=True, split_every=10
+    )
+
+    opt_fn = partial(multiple_inputs_optimize_dag, max_total_num_input_blocks=40)
+
+    cubed.visualize(
+        *(result[var].data for var in ("anom_u", "anom_v", "uv")),
+        filename=tmp_path / f"quadratic_means_xarray_{t_length}-unoptimized",
+        optimize_graph=False,
+        show_hidden=True,
+    )
+    cubed.visualize(
+        *(result[var].data for var in ("anom_u", "anom_v", "uv")),
+        filename=tmp_path / f"quadratic_means_xarray_{t_length}",
+        optimize_function=opt_fn,
+        show_hidden=True,
+    )
 
     # time only the computing of the result
-    computed_result = run(result, executor=spec.executor, benchmarks=benchmark_time)
+    computed_result = run(
+        result,
+        executor=spec.executor,
+        benchmarks=benchmark_time,
+        optimize_function=opt_fn,
+        compute_arrays_in_parallel=True,
+        callbacks=[RichProgressBar()],
+    )
 
     # TODO check result is correct here
+    assert computed_result is not None
+
+    # delete zarr test data (not timed)
+    for path in paths:
+        try:
+            fs, _, _ = fsspec.get_fs_token_paths(path)
+            fs.rm(path, recursive=True)
+        except FileNotFoundError:
+            pass

--- a/tests/configs/lithops_aws.yaml
+++ b/tests/configs/lithops_aws.yaml
@@ -1,0 +1,7 @@
+spec:
+  work_dir: "s3://cubed-$USER-temp"
+  allowed_mem: "2GB"
+  executor_name: "lithops"
+  executor_options:
+    runtime: "cubed-runtime"
+    runtime_memory: 2000

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,11 +24,11 @@ from benchmark_schema import TestRun
 
 
 RUNTIME_CONFIGS = [
-    'configs/local_single-threaded.yaml'
-    #'configs/lithops_gcf.yaml'
-    #'configs/lithops_aws.yaml'
-    #'configs/lithops_aws_1Z.yaml'
-    #'configs/coiled_aws.yaml'
+    'configs/local_single-threaded.yaml',
+    #'configs/lithops_gcf.yaml',
+    #'configs/lithops_aws.yaml',
+    #'configs/lithops_aws_1Z.yaml',
+    #'configs/coiled_aws.yaml',
 ]
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,14 +24,14 @@ def run(
         result, 
         executor,
         benchmarks,
+        **kwargs
     ):
 
     with benchmarks:
 
-        # TODO: cubed.compute won't yet work on an xarray object (like dask.compute does) because xarray has magic dask dunder methods
-        computed_result = cubed.compute(
-            result, 
+        computed_result = result.compute(
             executor=executor,
+            **kwargs
         )
 
     # TODO clean up by deleting intermediate data here?


### PR DESCRIPTION
* Update test to use Xarray
* Write test data to Zarr files and delete at end (outside of timing context)
* Add a config file for running on Lithops AWS (commented out for the moment)

I had to install the following packages (Xarray is pinned due to namedarray changes):

```shell
pip install pytest-xdist filelock 'xarray==2023.10.0' cubed_xarray lithops rich pydot s3fs
```

Then I could run some tests on Lithops:

```shell
pytest --benchmark -s 'tests/benchmarks/test_array.py::test_quadratic_means_xarray[configs/lithops_aws.yaml-50]'
pytest --benchmark -s 'tests/benchmarks/test_array.py::test_quadratic_means_xarray[configs/lithops_aws.yaml-500]'
pytest --benchmark -s 'tests/benchmarks/test_array.py::test_quadratic_means_xarray[configs/lithops_aws.yaml-5000]'
```

Note that Pytest `-s` option enables the Cubed's Rich progress bars, which is helpful when running a computation interactively.

```
$ duckdb benchmark.db
D select name, duration from test_run where name like '%lithops%';
┌────────────────────────────────────────────────────────────┬────────────────────┐
│                            name                            │      duration      │
│                          varchar                           │       double       │
├────────────────────────────────────────────────────────────┼────────────────────┤
│ test_quadratic_means_xarray[configs/lithops_aws.yaml-50]   │  34.91558289527893 │
│ test_quadratic_means_xarray[configs/lithops_aws.yaml-500]  │ 56.183167934417725 │
│ test_quadratic_means_xarray[configs/lithops_aws.yaml-5000] │  66.49491095542908 │
└────────────────────────────────────────────────────────────┴────────────────────┘

```
