### PR TITLE
benchmark memory usage

### DIFF
--- a/benchmark_schema.py
+++ b/benchmark_schema.py
@@ -36,9 +36,9 @@ class TestRun(Base):
     duration = Column(Float, nullable=True)
 
     # Memory data
+    projected_memory = Column(Float, nullable=True)
     average_memory = Column(Float, nullable=True)
     peak_memory = Column(Float, nullable=True)
-    projected_memory = Column(Float, nullable=True)
 
     # Other diagnostics data
     number_of_tasks_run = Column(Integer, nullable=True)

--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -9,7 +9,8 @@ import cubed
 import cubed.random
 from cubed.core.optimization import multiple_inputs_optimize_dag
 from cubed.extensions.rich import RichProgressBar
-from cubed.runtime.executors.python import PythonDagExecutor
+from cubed.runtime.executors.python import PythonDagExecutor 
+from cubed.runtime.executors.python_async import AsyncPythonDagExecutor
 
 from ..utils import run
 
@@ -18,7 +19,7 @@ from ..utils import run
 def test_quadratic_means_xarray(tmp_path, runtime, benchmark_all, t_length):
     spec = runtime
 
-    if isinstance(spec.executor, PythonDagExecutor) and t_length > 50:
+    if isinstance(spec.executor, (PythonDagExecutor, AsyncPythonDagExecutor)) and t_length > 50:
         pytest.skip(f"Don't run large computation on {type(spec.executor)}")
 
     # set the random seed to ensure deterministic results

--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -6,7 +6,7 @@ import cubed.array_api as xp
 from ..utils import run
 
 
-def test_quad_means(runtime, benchmark_time):
+def test_quad_means(runtime, benchmark_all):
     # from cubed.tests.test_core.test_plan_quad_means
 
     spec = runtime
@@ -23,6 +23,6 @@ def test_quad_means(runtime, benchmark_time):
     result = xp.mean(uv, axis=0, split_every=10, use_new_impl=True)
 
     # time only the computing of the result
-    computed_result = run(result, executor=spec.executor, benchmarks=benchmark_time)
+    computed_result = run(result, executor=spec.executor, benchmarks=benchmark_all)
 
     # TODO check result is correct here

--- a/tests/configs/local_async.yaml
+++ b/tests/configs/local_async.yaml
@@ -1,0 +1,4 @@
+spec:
+  work_dir: "temp/"
+  allowed_mem: "2GB"
+  executor_name: "threads"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,15 +232,15 @@ def benchmark_memory(test_run_benchmark):
             plan_df = pd.DataFrame(history.plan)
             events_df = pd.DataFrame(history.events)
 
+            plan_df["projected_mem_mb"] = plan_df["projected_mem"] / 1_000_000
             events_df["peak_measured_mem_end_mb"] = (
                 events_df["peak_measured_mem_end"] / 1_000_000
             )
-            plan_df["projected_mem_mb"] = plan_df["projected_mem"] / 1_000_000
-            # TODO average memory usage
-
-            test_run_benchmark.peak_memory = float(events_df["peak_measured_mem_end_mb"].max())
+            
             test_run_benchmark.projected_memory = float(plan_df["projected_mem_mb"].max())
-
+            test_run_benchmark.peak_memory = float(events_df["peak_measured_mem_end_mb"].max())
+            test_run_benchmark.average_memory = float(events_df["peak_measured_mem_end_mb"].mean())
+            
     yield _benchmark_memory
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from benchmark_schema import TestRun
 
 RUNTIME_CONFIGS = [
     'configs/local_single-threaded.yaml',
+    #'configs/local_async.yaml',
     #'configs/lithops_gcf.yaml',
     #'configs/lithops_aws.yaml',
     #'configs/lithops_aws_1Z.yaml',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,6 +197,92 @@ def benchmark_time(test_run_benchmark):
     return _benchmark_time()
 
 
+@pytest.fixture(scope="function")
+def benchmark_memory(test_run_benchmark):
+    """Benchmark the memory usage of executing some code.
+
+    Yields
+    ------
+    Context manager factory function which takes an instantiated cubed HistoryCallback object
+    as input. The context manager records peak and average memory usage of
+    executing the ``with`` statement if run as part of a benchmark,
+    or does nothing otherwise.
+
+    Example
+    -------
+    .. code-block:: python
+
+        def test_something(benchmark_memory):
+            history = cubed.extensions.HistoryCallback()
+                with benchmark_memory(history):
+                    do_something()
+    """
+
+    @contextlib.contextmanager
+    def _benchmark_memory(history):
+        if not test_run_benchmark:
+            yield
+        else:
+            yield
+
+            import pandas as pd
+
+            # read off the memory values and write them into the database
+            plan_df = pd.DataFrame(history.plan)
+            events_df = pd.DataFrame(history.events)
+
+            events_df["peak_measured_mem_end_mb"] = (
+                events_df["peak_measured_mem_end"] / 1_000_000
+            )
+            plan_df["projected_mem_mb"] = plan_df["projected_mem"] / 1_000_000
+            # TODO average memory usage
+
+            test_run_benchmark.peak_memory = float(events_df["peak_measured_mem_end_mb"].max())
+            test_run_benchmark.projected_memory = float(plan_df["projected_mem_mb"].max())
+
+    yield _benchmark_memory
+
+
+@pytest.fixture(scope="function")
+def benchmark_all(
+    benchmark_memory,
+    benchmark_time,
+):
+    """Benchmark all available metrics and extracts cluster information
+
+    Yields
+    ------
+    Context manager factory function which takes an instantiated cubed HistoryCallback object
+    as input. The context manager records peak and average memory usage of
+    executing the ``with`` statement if run as part of a benchmark,
+    or does nothing otherwise.
+
+    Example
+    -------
+    .. code-block:: python
+
+        def test_something(benchmark_memory):
+            history = cubed.extensions.HistoryCallback()
+                with benchmark_memory(history):
+                    do_something()
+    
+    See Also
+    --------
+    benchmark_memory
+    benchmark_time
+    """
+
+    @contextlib.contextmanager
+    def _benchmark_all(history):
+        with (
+            benchmark_memory(history),
+            benchmark_time,
+        ):
+            yield
+
+    yield _benchmark_all
+
+
 @pytest.fixture(params=RUNTIME_CONFIGS)
 def runtime(request) -> Iterator[cubed.Spec]:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,9 +214,9 @@ def benchmark_memory(test_run_benchmark):
     .. code-block:: python
 
         def test_something(benchmark_memory):
-            history = cubed.extensions.HistoryCallback()
-                with benchmark_memory(history):
-                    do_something()
+            history = cubed.extensions.history.HistoryCallback()
+            with benchmark_memory(history):
+                cubed.compute(*arrs, callbacks=[history])
     """
 
     @contextlib.contextmanager
@@ -262,10 +262,10 @@ def benchmark_all(
     -------
     .. code-block:: python
 
-        def test_something(benchmark_memory):
-            history = cubed.extensions.HistoryCallback()
-                with benchmark_memory(history):
-                    do_something()
+        def test_something(benchmark_all):
+            history = cubed.extensions.history.HistoryCallback()
+            with benchmark_all(history):
+                cubed.compute(*arrs, callbacks=[history])
     
     See Also
     --------

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,9 +28,11 @@ def run(
         **kwargs
     ):
 
-    callbacks = kwargs.get('callbacks', [])
+    # add the history callback to any other callback already passed
     history = HistoryCallback()
+    callbacks = kwargs.get('callbacks', [])
     callbacks.append(history)
+    kwargs['callbacks'] = callbacks
 
     with benchmarks(history):
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@ import os
 import yaml
 
 import cubed
+from cubed.extensions.history import HistoryCallback
 from cubed.spec import spec_from_config
 from cubed import config
 
@@ -26,14 +27,17 @@ def run(
         benchmarks,
     ):
 
-    with benchmarks:
+    history = HistoryCallback()
+
+    with benchmarks(history):
 
         # TODO: cubed.compute won't yet work on an xarray object (like dask.compute does) because xarray has magic dask dunder methods
         computed_result = cubed.compute(
             result, 
             executor=executor,
+            callbacks=[history]
         )
 
     # TODO clean up by deleting intermediate data here?
-        
+
     return computed_result


### PR DESCRIPTION
This approach seems to mostly work

```
D select name, projected_memory from test_run;
┌─────────────────────────────────────────────────────┬──────────────────┐
│                        name                         │ projected_memory │
│                       varchar                       │      double      │
├─────────────────────────────────────────────────────┼──────────────────┤
│ test_quad_means[configs/local_single-threaded.yaml] │        1009.6192 │
└─────────────────────────────────────────────────────┴──────────────────┘
D 
```

except that the measured_mem doesn't appear to be being populated - if I print the `events_df` I get 

```
             name  num_tasks  ... peak_measured_mem_start peak_measured_mem_end
0   create-arrays          1  ...                    None                  None
1   create-arrays          1  ...                    None                  None
2   create-arrays          1  ...                    None                  None
3   create-arrays          1  ...                    None                  None
4          op-003          1  ...                    None                  None
5          op-003          1  ...                    None                  None
...
```