### PR TITLE
Have separate conda envs for different executors and clouds

### DIFF
--- a/.github/workflows/.lithops_config_aws.template
+++ b/.github/workflows/.lithops_config_aws.template
@@ -1,0 +1,17 @@
+lithops:
+  backend: aws_lambda
+  storage: aws_s3
+  storage_bucket: lithops-tom-data
+  log_level: WARN
+
+aws:
+  access_key_id:
+  secret_access_key:
+
+aws_lambda:
+  region_name: eu-west-1
+  execution_role: arn:aws:iam::111560892610:role/lithops-execution-role
+
+aws_s3:
+  region_name: eu-west-1
+  storage_bucket: lithops-tom-data

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,75 @@
+name: Benchmarks
+
+on:
+  pull_request:
+  schedule:
+    # Mon-Fri at 04:39 UTC, see https://crontab.guru/
+    - cron: "39 4 * * 1-5"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  # Required shell entrypoint to have properly activated conda environments
+  run:
+    shell: bash -l {0}
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.11"]
+        extra-env: [""]
+        cubed-config: [tests/configs/local_single-threaded.yaml]
+        name_prefix: [tests]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          use-mamba: true
+          condarc-file: ci/condarc
+          python-version: ${{ matrix.python_version }}
+          environment-file: ci/environment.yml
+
+      - name: Add extra packages to environment
+        if: ${{ matrix.extra-env != '' }}
+        run: mamba env update --file ${{ matrix.extra-env }}
+
+      - name: Add test dependencies
+        run: mamba env update --file ci/environment-test.yml
+
+      - name: Dump environment
+        run: |
+          # For debugging
+          echo -e "--\n--Conda Environment (re-create this with \`conda env create --name <name> -f <output_file>\`)\n--"
+          mamba env export | grep -E -v '^prefix:.*$'
+
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
+
+      - name: Run benchmarks
+        env:
+          CUBED_CONFIG: ${{ matrix.cubed-config }}
+          DB_NAME: ${{ matrix.name_prefix }}-${{ matrix.os }}-py${{ matrix.python_version }}.db
+        run: |
+          pytest --benchmark --basetemp=pytest-temp
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ${{ matrix.name_prefix }}-${{ matrix.os }}-py${{ matrix.python_version }}
+          path: |
+            ${{ matrix.name_prefix }}-${{ matrix.os }}-py${{ matrix.python_version }}.db
+            pytest-temp/
+            mamba_env_export.yml

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,7 +1,6 @@
 name: Benchmarks
 
 on:
-  pull_request:
   schedule:
     # Mon-Fri at 04:39 UTC, see https://crontab.guru/
     - cron: "39 4 * * 1-5"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,10 +27,27 @@ jobs:
         extra-env: [""]
         cubed-config: [tests/configs/local_single-threaded.yaml]
         name_prefix: [tests]
+        include:
+          - os: "ubuntu-latest"
+            python-version: "3.11"
+            extra-env: ci/environment-lithops-aws.yml
+            cubed-config: tests/configs/lithops_aws.yaml
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Copy lithops configuration template
+        run: |
+          cp $GITHUB_WORKSPACE/.github/workflows/.lithops_config_aws.template $GITHUB_WORKSPACE/.github/workflows/.lithops_config_aws
+
+      - name: Configure lithops
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: ${{ github.workspace }}/.github/workflows/.lithops_config_aws
+        env:
+          aws.access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws.secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Set up environment
         uses: conda-incubator/setup-miniconda@v2
@@ -59,8 +76,11 @@ jobs:
 
       - name: Run benchmarks
         env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           CUBED_CONFIG: ${{ matrix.cubed-config }}
           DB_NAME: ${{ matrix.name_prefix }}-${{ matrix.os }}-py${{ matrix.python_version }}.db
+          LITHOPS_CONFIG_FILE: ${{ github.workspace }}/.github/workflows/.lithops_config_aws
         run: |
           pytest --benchmark --basetemp=pytest-temp
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Set of Cubed benchmarks to run at scale on various executors.
 
 The `cubed benchmarks` test suite can be run locally with the following steps:
 
-1. Create a conda environment using `mamba env create -n test-env -f ci/environment.yaml`
+1. Create a conda environment using `mamba env create -n test-env -f ci/environment.yml`
 2. Activate the environment with `conda activate test-env`
 3. Add test packages with `mamba env update -f ci/environment-test.yml`
-4. Run tests with `python -m pytest tests`
+4. Run tests with `CUBED_CONFIG=tests/configs/local_single-threaded.yaml pytest`
 
 ## Benchmarking
 
@@ -36,6 +36,7 @@ You can compare with historical data by downloading the global database from S3 
 
 ```bash
 aws s3 cp s3://cubed-runtime-ci/benchmarks/benchmark.db ./benchmark.db
+export CUBED_CONFIG=...
 pytest --benchmark
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Set of Cubed benchmarks to run at scale on various executors.
 
 The `cubed benchmarks` test suite can be run locally with the following steps:
 
-1. Create a conda environment using `ci/environment.yml`
-2. Run tests with `python -m pytest tests`.
+1. Create a conda environment using `mamba env create -n test-env -f ci/environment.yaml`
+2. Activate the environment with `conda activate test-env`
+3. Add test packages with `mamba env update -f ci/environment-test.yml`
+4. Run tests with `python -m pytest tests`
 
 ## Benchmarking
 

--- a/ci/condarc
+++ b/ci/condarc
@@ -1,0 +1,5 @@
+auto_activate_base: false
+remote_backoff_factor: 20
+remote_connect_timeout_secs: 20.0
+remote_max_retries: 10
+remote_read_timeout_secs: 60.0

--- a/ci/environment-lithops-aws.yml
+++ b/ci/environment-lithops-aws.yml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+dependencies:
+  - pip
+  - s3fs
+  - pip:
+    - lithops[aws]
+

--- a/ci/environment-lithops-gcp.yml
+++ b/ci/environment-lithops-gcp.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+dependencies:
+  - pip
+  - gcsfs
+  - pip:
+    - lithops[gcp]

--- a/ci/environment-test.yml
+++ b/ci/environment-test.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+dependencies:
+  # Testing dependencies
+  - filelock
+  - pytest
+  - pytest-xdist

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,9 +1,10 @@
 channels:
   - conda-forge
 dependencies:
-
   - python >=3.9,<=3.11
   - pip
-  - pytest
-  - cubed >=0.13.0
+  - cubed-xarray
+  - xarray ==2023.10.0
   - sqlalchemy ==2.0.23
+  - pip:
+    - cubed[diagnostics] >=0.13.0

--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -15,7 +15,7 @@ from cubed.runtime.executors.python_async import AsyncPythonDagExecutor
 from ..utils import run
 
 
-@pytest.mark.parametrize("t_length", [50])
+@pytest.mark.parametrize("t_length", [50, 500, 5000])
 def test_quadratic_means_xarray(tmp_path, runtime, benchmark_all, t_length):
     spec = runtime
 

--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -15,7 +15,7 @@ from cubed.runtime.executors.python_async import AsyncPythonDagExecutor
 from ..utils import run
 
 
-@pytest.mark.parametrize("t_length", [50, 500, 5000])
+@pytest.mark.parametrize("t_length", [50])
 def test_quadratic_means_xarray(tmp_path, runtime, benchmark_all, t_length):
     spec = runtime
 

--- a/tests/configs/lithops_aws.yaml
+++ b/tests/configs/lithops_aws.yaml
@@ -1,5 +1,5 @@
 spec:
-  work_dir: "s3://cubed-$USER-temp"
+  work_dir: "s3://cubed-tom-temp"
   allowed_mem: "2GB"
   executor_name: "lithops"
   executor_options:

--- a/tests/configs/lithops_gcp.yaml
+++ b/tests/configs/lithops_gcp.yaml
@@ -1,0 +1,7 @@
+spec:
+  work_dir: "gs://cubed-$USER-temp"
+  allowed_mem: "2GB"
+  executor_name: "lithops"
+  executor_options:
+    runtime: "cubed-runtime"
+    runtime_memory: 2048

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,13 @@ import subprocess
 import cubed
 import xarray
 import cubed_xarray
-import lithops
 
-from .utils import spec_from_config_file
+try:
+    import lithops
+except ImportError:
+    lithops = None
+
+from cubed import config
 
 from benchmark_schema import TestRun
 
@@ -143,7 +147,7 @@ def test_run_benchmark(benchmark_db_session, request, testrun_uid):
             cubed_version=cubed.__version__,
             cubed_xarray_version=cubed_xarray.__version__,
             xarray_version=xarray.__version__,
-            lithops_version=lithops.__version__, 
+            lithops_version=lithops.__version__ if lithops else None, 
             python_version=".".join(map(str, sys.version_info)),
             platform=sys.platform,
             ci_run_url=WORKFLOW_URL,
@@ -330,11 +334,6 @@ def benchmark_all(
     yield _benchmark_all
 
 
-@pytest.fixture(params=RUNTIME_CONFIGS)
-def runtime(request) -> Iterator[cubed.Spec]:
-    """
-    Yields a cubed.Spec for each .yaml file in the /configs/ directory, 
-    so any test parametrized with this fixture will run for all executors.
-    """
-    config_filepath = request.param
-    yield spec_from_config_file(config_filepath)
+@pytest.fixture()
+def runtime() -> cubed.Spec:
+    return cubed.spec.spec_from_config(config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ from benchmark_schema import TestRun
 RUNTIME_CONFIGS = [
     'configs/local_single-threaded.yaml',
     #'configs/local_async.yaml',
-    #'configs/lithops_gcf.yaml',
+    #'configs/lithops_gcp.yaml',
     #'configs/lithops_aws.yaml',
     #'configs/lithops_aws_1Z.yaml',
     #'configs/coiled_aws.yaml',


### PR DESCRIPTION
Initial work for #5.

I think it would be useful to standardise the naming of the config and conda env files. Something like `{executor-name}_{cloud}`, so we'd have:
* `single-threaded` (there's no cloud for this one, so we just drop it, alternatively we could have `single-threaded_nocloud` or something)
* `lithops_aws`
* `lithops_gcp`

If we wanted more options within a config (e.g. because we wanted to try a different serverless runtime), we could just add more modifiers, e.g. `lithops_gcp_cloudrun`. But I don't think we need that yet.