### PR TITLE
Record the Cubed config file in the database

### DIFF
--- a/benchmark_schema.py
+++ b/benchmark_schema.py
@@ -26,6 +26,7 @@ class TestRun(Base):
     lithops_version = Column(String, nullable=True)
     python_version = Column(String, nullable=True)
     platform = Column(String, nullable=True)
+    cubed_config_file = Column(String, nullable=True)
 
     # CI runner data
     ci_run_url = Column(String, nullable=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,16 +27,6 @@ from cubed import config
 from benchmark_schema import TestRun
 
 
-RUNTIME_CONFIGS = [
-    'configs/local_single-threaded.yaml',
-    #'configs/local_async.yaml',
-    #'configs/lithops_gcp.yaml',
-    #'configs/lithops_aws.yaml',
-    #'configs/lithops_aws_1Z.yaml',
-    #'configs/coiled_aws.yaml',
-]
-
-
 TEST_DIR = pathlib.Path("./tests").absolute()
 
 
@@ -150,6 +140,7 @@ def test_run_benchmark(benchmark_db_session, request, testrun_uid):
             lithops_version=lithops.__version__ if lithops else None, 
             python_version=".".join(map(str, sys.version_info)),
             platform=sys.platform,
+            cubed_config_file=os.getenv("CUBED_CONFIG"),
             ci_run_url=WORKFLOW_URL,
         )
         yield run


### PR DESCRIPTION
We need this to distinguish runtimes (e.g. AWS vs GCP) now that each config is parameterized from a GitHub Actions matrix, rather than the pytest fixture. 