### PR TITLE
Populate setup_outcome, call_outcome, and teardown_outcome

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -337,3 +337,22 @@ def benchmark_all(
 @pytest.fixture()
 def runtime() -> cubed.Spec:
     return cubed.spec.spec_from_config(config)
+
+
+# ############################################### #
+#        END BENCHMARKING RELATED                 #
+# ############################################### #
+
+
+# this code was taken from pytest docs
+# https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    # execute all other hooks to obtain the report object
+    outcome = yield
+    rep = outcome.get_result()
+
+    # set a report attribute for each phase of a call, which can
+    # be "setup", "call", "teardown"
+
+    setattr(item, "rep_" + rep.when, rep)


### PR DESCRIPTION
They were always None, which turned out to be because a function in conftest.py was missing.