### PR TITLE
Add CI step to combine results DB with historical one in S3

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,7 +16,7 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  test:
+  tests:
     name: ${{ matrix.name_prefix }} ${{ matrix.os }} py${{ matrix.python_version }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -118,3 +118,59 @@ jobs:
             history/
             pytest-temp/
             mamba_env_export.yml
+
+  process-results:
+    needs: tests
+    name: Combine separate benchmark results
+    if: always() && github.repository == 'cubed-dev/benchmarks'
+    runs-on: ubuntu-latest
+    concurrency:
+      # Fairly strict concurrency rule to avoid stepping on benchmark db.
+      group: process-benchmarks
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install alembic
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: benchmarks
+
+      - name: Download benchmark db
+        env:
+          AWS_ACCESS_KEY_ID: ${{ ssecrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-2 # this is needed for boto for some reason
+          DB_NAME: benchmark.db
+        run: |
+          aws s3 cp s3://cubed-runtime-ci/benchmarks/$DB_NAME . || true
+
+      - name: Combine benchmarks
+        run: |
+          ls -lhR benchmarks
+          bash ci/scripts/combine-dbs.sh
+
+      - name: Upload benchmark db
+        if: always() && github.ref == 'refs/heads/main' && github.repository == 'cubed-dev/benchmarks'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-2 # this is needed for boto for some reason
+          DB_NAME: benchmark.db
+        run: |
+          aws s3 cp $DB_NAME s3://cubed-runtime-ci/benchmarks/
+
+      - name: Upload benchmark results as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: benchmark
+          path: benchmark.db

--- a/ci/scripts/combine-dbs.sh
+++ b/ci/scripts/combine-dbs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euxo pipefail
+
+DB_NAME=${DB_NAME:-'benchmark.db'}
+
+# Possibly apply migrations to the main db,
+# working on a copy with a known name so it's
+# easier to refer to in sqlite
+if [ -f "$DB_NAME" ]; then
+  cp "$DB_NAME" benchmark.tmp.db
+else
+  sqlite3 benchmark.tmp.db "VACUUM;"
+fi
+# Migrations are not supported yet
+# DB_NAME=benchmark.tmp.db alembic upgrade head
+
+# Merge in the individual job dbs into our working copy
+for FILE in $(find benchmarks -name "*.db")
+do
+  # Skip the output DB if we see it
+  if [ ${FILE##*/} == $DB_NAME ]; then
+    echo "Skipping $FILE"
+    continue
+  fi
+  echo "Processing $FILE"
+  # Copy the individual table into the primary one. We make an intermediate
+  # temp table so that we can null out the primary keys and reset the
+  # autoincrementing
+  sqlite3 "$FILE" <<EOF
+attach "benchmark.tmp.db" as lead;
+create temporary table tmp as select * from main.test_run;
+update tmp set id=NULL;
+insert into lead.test_run select * from tmp;
+detach database lead;
+EOF
+done
+
+mv benchmark.tmp.db "$DB_NAME"


### PR DESCRIPTION
Fixes #13 

I haven't tested this yet. To do so I plan to upload a DB from a successful run (after #18 is merged), then try triggering the workflow in this branch.

Note that this doesn't include migrations yet - they can be added at a later stage.